### PR TITLE
renaming highest_confirm_block_repo_id

### DIFF
--- a/hubgrep_indexer/lib/state_manager/abstract_state_manager.py
+++ b/hubgrep_indexer/lib/state_manager/abstract_state_manager.py
@@ -89,7 +89,7 @@ class AbstractStateManager:
     def get_state_dict(self, hoster_prefix: str) -> Dict:
         return dict(
             highest_block_repo_id=self.get_highest_block_repo_id(hoster_prefix),
-            highest_confirmed_repo_id=self.get_highest_confirmed_repo_id(hoster_prefix),
+            highest_confirmed_repo_id=self.get_highest_confirmed_block_repo_id(hoster_prefix),
             empty_results_count=self.get_empty_results_counter(hoster_prefix),
             run_created_ts=self.get_run_created_ts(hoster_prefix),
             run_is_finished=self.get_is_run_finished(hoster_prefix),
@@ -109,14 +109,14 @@ class AbstractStateManager:
         """
         raise NotImplementedError
 
-    def get_highest_confirmed_repo_id(self, hoster_prefix: str) -> int:
+    def get_highest_confirmed_block_repo_id(self, hoster_prefix: str) -> int:
         """
         The highest (last) repo_id we have received from crawlers,
         guaranteeing its existence.
         """
         raise NotImplementedError
 
-    def set_highest_confirmed_repo_id(self, hoster_prefix: str, repo_id):
+    def set_highest_confirmed_block_repo_id(self, hoster_prefix: str, repo_id):
         """
         The highest (last) repo_id we have received from crawlers,
         guaranteeing its existence.
@@ -179,7 +179,7 @@ class AbstractStateManager:
         self.set_run_created_ts(hoster_prefix, None)
         self.set_is_run_finished(hoster_prefix, False)
         self.set_highest_block_repo_id(hoster_prefix, 0)
-        self.set_highest_confirmed_repo_id(hoster_prefix, 0)
+        self.set_highest_confirmed_block_repo_id(hoster_prefix, 0)
         self.set_empty_results_counter(hoster_prefix, 0)
         self._reset_blocks(hoster_prefix)
 
@@ -287,10 +287,10 @@ class LocalStateManager(AbstractStateManager):
         block = hoster_blocks.pop(block_uid)
         return block
 
-    def set_highest_confirmed_repo_id(self, hoster_prefix: str, repo_id: int):
+    def set_highest_confirmed_block_repo_id(self, hoster_prefix: str, repo_id: int):
         self.highest_confirmed_repo_ids[hoster_prefix] = repo_id
 
-    def get_highest_confirmed_repo_id(self, hoster_prefix: str) -> int:
+    def get_highest_confirmed_block_repo_id(self, hoster_prefix: str) -> int:
         if not self.highest_confirmed_repo_ids.get(hoster_prefix, False):
             self.highest_confirmed_repo_ids[hoster_prefix] = 0
         return self.highest_confirmed_repo_ids[hoster_prefix]

--- a/hubgrep_indexer/lib/state_manager/host_state_helpers.py
+++ b/hubgrep_indexer/lib/state_manager/host_state_helpers.py
@@ -74,8 +74,7 @@ class IStateHelper:
                 repo_id = block.ids[-1]
             else:
                 repo_id = block.to_id
-            # TODO before if/else does not take into account if we actually GOT this repo successfully
-            state_manager.set_highest_confirmed_repo_id(
+            state_manager.set_highest_confirmed_block_repo_id(
                 hoster_prefix=hosting_service_id, repo_id=repo_id)
 
         # finally return and terminate the while loop
@@ -103,7 +102,7 @@ class IStateHelper:
         """
 
         # get the highest repo id we have seen
-        highest_confirmed_id = state_manager.get_highest_confirmed_repo_id(
+        highest_confirmed_id = state_manager.get_highest_confirmed_block_repo_id(
             hoster_prefix=hosting_service_id)
 
         # get end of the block behind the last confirmed one

--- a/hubgrep_indexer/lib/state_manager/redis_state_manager.py
+++ b/hubgrep_indexer/lib/state_manager/redis_state_manager.py
@@ -20,7 +20,7 @@ class RedisStateManager(AbstractStateManager):
         self.run_created_ts_key = "run_created_ts"
         self.block_map_key = "blocks"
         self.highest_block_repo_id_key = "highest_block_repo_id"
-        self.highest_confirmed_repo_id_key = "highest_confirmed_repo_id"
+        self.highest_confirmed_block_repo_id_key = "highest_confirmed_block_repo_id"
         self.empty_results_counter_key = "empty_results_counter"
         self.run_is_finished_key = "run_is_finished"
         self.lock_key = "lock"
@@ -47,12 +47,12 @@ class RedisStateManager(AbstractStateManager):
             highest_repo_id = int(highest_repo_id_str)
         return highest_repo_id
 
-    def set_highest_confirmed_repo_id(self, hoster_prefix: str, repo_id: int):
-        redis_key = self._get_redis_key(hoster_prefix, self.highest_confirmed_repo_id_key)
+    def set_highest_confirmed_block_repo_id(self, hoster_prefix: str, repo_id: int):
+        redis_key = self._get_redis_key(hoster_prefix, self.highest_confirmed_block_repo_id_key)
         self.redis.set(redis_key, repo_id)
 
-    def get_highest_confirmed_repo_id(self, hoster_prefix: str) -> int:
-        redis_key = self._get_redis_key(hoster_prefix, self.highest_confirmed_repo_id_key)
+    def get_highest_confirmed_block_repo_id(self, hoster_prefix: str) -> int:
+        redis_key = self._get_redis_key(hoster_prefix, self.highest_confirmed_block_repo_id_key)
         repo_id_str: str = self.redis.get(redis_key)
         if not repo_id_str:
             highest_repo_id = 0

--- a/tests/lib/state_manager/test_host_state_helpers.py
+++ b/tests/lib/state_manager/test_host_state_helpers.py
@@ -32,7 +32,7 @@ class TestHostStateHelpers:
         print(f"testing for: {hoster_type}")
         # init state for a already completed block
         old_block = state_manager.get_next_block(hoster_prefix=HOSTER_PREFIX)
-        state_manager.set_highest_confirmed_repo_id(
+        state_manager.set_highest_confirmed_block_repo_id(
             hoster_prefix=HOSTER_PREFIX, repo_id=old_block.to_id
         )
         state_manager.finish_block(hoster_prefix=HOSTER_PREFIX, block_uid=old_block.uid)
@@ -89,7 +89,7 @@ class TestHostStateHelpers:
         new_run_created_ts = state_manager.get_run_created_ts(
             hoster_prefix=HOSTER_PREFIX
         )
-        new_highest_confirmed_id = state_manager.get_highest_confirmed_repo_id(
+        new_highest_confirmed_id = state_manager.get_highest_confirmed_block_repo_id(
             hoster_prefix=HOSTER_PREFIX
         )
         new_highest_block_id = state_manager.get_highest_block_repo_id(
@@ -111,7 +111,7 @@ class TestHostStateHelpers:
         print(f"testing for: {hoster_type}")
         # init with an old block state (attempt to raise side-effects to fail this test, if we introduce them)
         old_block = state_manager.get_next_block(hoster_prefix=HOSTER_PREFIX)
-        state_manager.set_highest_confirmed_repo_id(
+        state_manager.set_highest_confirmed_block_repo_id(
             hoster_prefix=HOSTER_PREFIX, repo_id=old_block.to_id
         )
         state_manager.finish_block(hoster_prefix=HOSTER_PREFIX, block_uid=old_block.uid)

--- a/tests/lib/state_manager/test_state_manager.py
+++ b/tests/lib/state_manager/test_state_manager.py
@@ -71,7 +71,7 @@ class TestLocalStateManager:
         highest_confirmed_id = 40
         highest_block_id = 100
         state_manager.set_highest_block_repo_id(HOSTER_PREFIX, highest_block_id)
-        state_manager.set_highest_confirmed_repo_id(HOSTER_PREFIX, highest_confirmed_id)
+        state_manager.set_highest_confirmed_block_repo_id(HOSTER_PREFIX, highest_confirmed_id)
         state_manager.set_run_created_ts(HOSTER_PREFIX, created_ts)
         # False is implied
         # state_manager.set_run_is_finished(HOSTER_PREFIX, False)
@@ -79,7 +79,7 @@ class TestLocalStateManager:
         state_manager.finish_run(HOSTER_PREFIX)
 
         assert state_manager.get_highest_block_repo_id(HOSTER_PREFIX) == highest_block_id
-        assert state_manager.get_highest_confirmed_repo_id(HOSTER_PREFIX) == highest_confirmed_id
+        assert state_manager.get_highest_confirmed_block_repo_id(HOSTER_PREFIX) == highest_confirmed_id
         assert state_manager.get_run_created_ts(HOSTER_PREFIX) == created_ts
         assert state_manager.get_is_run_finished(HOSTER_PREFIX)
 
@@ -119,7 +119,7 @@ class TestLocalStateManager:
         old_block = state_manager.get_next_block(hoster_prefix=HOSTER_PREFIX)
         old_run_created_ts = state_manager.get_run_created_ts(
             hoster_prefix=HOSTER_PREFIX)
-        state_manager.set_highest_confirmed_repo_id(
+        state_manager.set_highest_confirmed_block_repo_id(
             hoster_prefix=HOSTER_PREFIX, repo_id=old_highest_confirmed_id)
         state_manager.set_highest_block_repo_id(
             hoster_prefix=HOSTER_PREFIX, repo_id=old_highest_block_id)
@@ -127,7 +127,7 @@ class TestLocalStateManager:
         new_block = state_manager.get_next_block(hoster_prefix=HOSTER_PREFIX)
 
         # test that our setup took effect (old block is gone, only new one left)
-        new_highest_confirmed_id = state_manager.get_highest_confirmed_repo_id(
+        new_highest_confirmed_id = state_manager.get_highest_confirmed_block_repo_id(
             hoster_prefix=HOSTER_PREFIX)
         new_highest_block_id = state_manager.get_highest_block_repo_id(
             hoster_prefix=HOSTER_PREFIX)


### PR DESCRIPTION
Works locally with a github crawler adding repos