### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2.1
 jobs:
   build-and-test:
     machine: true
+    environment:
+      HUBGREP_TEST_SQLALCHEMY_DATABASE_URI: postgresql://hubgrep:hubgrep@test_postgres:5432/hubgrep
     steps:
       - checkout
       - run: docker build -f Dockerfile.prod -t hubgrep_indexer:test .


### PR DESCRIPTION
circle-ci config to work with having a separate real postgres db.

Needed to make tests pass on circle-ci for PR: https://github.com/HubGrep/hubgrep_indexer/pull/31