### PR TITLE
WIP: waiting for "slow" or failed blocks

### DIFF
--- a/hubgrep_indexer/api_blueprint/__init__.py
+++ b/hubgrep_indexer/api_blueprint/__init__.py
@@ -5,3 +5,38 @@ api = Blueprint("api", __name__, url_prefix="/api/v1")
 from hubgrep_indexer.api_blueprint.hosters import hosters
 from hubgrep_indexer.api_blueprint.add_repos import add_repos
 from hubgrep_indexer.api_blueprint.get_block import get_block, get_loadbalanced_block
+
+"""
+# memleak tooling :)
+
+import logging
+logger = logging.getLogger(__name__)
+
+import gc
+import os
+import tracemalloc
+
+import psutil
+process = psutil.Process(os.getpid())
+tracemalloc.start()
+s = None
+
+
+@api.route('/memory')
+def print_memory():
+    return {'memory': process.memory_info().rss}
+
+
+@api.route("/snapshot")
+def snap():
+    global s
+    if not s:
+        s = tracemalloc.take_snapshot()
+        return "taken snapshot\n"
+    else:
+        lines = []
+        top_stats = tracemalloc.take_snapshot().compare_to(s, 'lineno')
+        for stat in top_stats[:15]:
+            lines.append(str(stat))
+        return "\n".join(lines)
+"""

--- a/hubgrep_indexer/lib/state_manager/abstract_state_manager.py
+++ b/hubgrep_indexer/lib/state_manager/abstract_state_manager.py
@@ -23,6 +23,13 @@ class Block:
         self.attempts_at = []
         self.status = ""
 
+    def is_dead(self):
+        """
+        we retried this block but it keeps failing
+        """
+        # todo
+        return False
+
     @classmethod
     def new(cls, from_id, to_id, run_created_ts=None, ids=None):
         block = Block()
@@ -236,6 +243,7 @@ class AbstractStateManager:
                 block.attempts_at.append(timestamp_now)
                 self.update_block(hoster_prefix=hoster_prefix, block=block)
                 return block
+        # todo: should we delete dead blocks here?
         return None
 
 

--- a/hubgrep_indexer/lib/state_manager/host_state_helpers.py
+++ b/hubgrep_indexer/lib/state_manager/host_state_helpers.py
@@ -29,44 +29,69 @@ class IStateHelper:
         - true/false if we reached end, None if block is unrelated to the current run
         """
         block = state_manager.get_block(
-            hoster_prefix=hosting_service_id, block_uid=block_uid)
+            hoster_prefix=hosting_service_id, block_uid=block_uid
+        )
 
         if not block:
             # Block has already been deleted from the previous run, no state changes
             logger.info(f"block no longer exists - no state changes, uid: {block_uid}")
             return None
-        else:
-            is_run_finished = state_manager.get_is_run_finished(
-                hoster_prefix=hosting_service_id)
-            if is_run_finished:
-                logger.info(f"skipping state update for outdated block, uid: {block_uid}")
-                # this Block belongs to an old run, so we avoid touching any state for it
-                return None
+
+        is_run_finished = state_manager.get_is_run_finished(
+            hoster_prefix=hosting_service_id
+        )
+        if is_run_finished:
+            logger.info(f"skipping state update for outdated block, uid: {block_uid}")
+
+            # run is finished (as in, we hit the end), but we may have blocks open
+            # so we dont trigger export-and-rotate until the blocks at least timed out
+
+            run_created_ts = state_manager.get_run_created_ts(
+                hoster_prefix=hosting_service_id
+            )
+            blocks = state_manager.get_blocks(hoster_prefix=hosting_service_id)
+
+            for block in blocks:
+                if block.run_created_ts == run_created_ts:
+                    # blocks open in this run, dont finish
+                    # todo:
+                    # we have some logic to retry a timedout block, (get_timed_out_block)
+                    # but where do we actually decide not to wait for them if it takes too long?
+                    return None
+
+            # this Block belongs to an old run, so we avoid touching any state for it
+            return None
 
         state_manager.finish_block(
-            hoster_prefix=hosting_service_id, block_uid=block_uid)
+            hoster_prefix=hosting_service_id, block_uid=block_uid
+        )
         if len(parsed_repos) == 0:
             state_manager.increment_empty_results_counter(
-                hoster_prefix=hosting_service_id, amount=1)
+                hoster_prefix=hosting_service_id, amount=1
+            )
         else:
             state_manager.set_empty_results_counter(
-                hoster_prefix=hosting_service_id, count=0)
+                hoster_prefix=hosting_service_id, count=0
+            )
 
         # check on the effects of the block transaction
         has_reached_end = cls.has_reached_end(
             hosting_service_id=hosting_service_id,
             state_manager=state_manager,
             parsed_repos=parsed_repos,
-            block=block)
+            block=block,
+        )
         has_too_many_empty = cls.has_too_many_consecutive_empty_results(
-            hosting_service_id=hosting_service_id,
-            state_manager=state_manager)
+            hosting_service_id=hosting_service_id, state_manager=state_manager
+        )
 
         if has_reached_end:
-            logger.info(f'crawler reached end for hoster: {hosting_service_id}')
+            logger.info(f"crawler reached end for hoster: {hosting_service_id}")
             state_manager.finish_run(hoster_prefix=hosting_service_id)
         elif has_too_many_empty:
-            logger.info(f'crawler reach max empty results for hoster: {hosting_service_id}')
+            logger.info(
+                f"crawler reach max empty results for hoster: {hosting_service_id}"
+            )
             state_manager.finish_run(hoster_prefix=hosting_service_id)
         else:
             # we are somewhere in the middle of a hosters repos
@@ -112,7 +137,8 @@ class IStateHelper:
 
         # get the ending repo id from a block we have seen containing results
         highest_confirmed_id = state_manager.get_highest_confirmed_block_repo_id(
-            hoster_prefix=hosting_service_id)
+            hoster_prefix=hosting_service_id
+        )
 
         # get ending repo id of the block after the last confirmed one
         last_block_id = highest_confirmed_id + state_manager.batch_size

--- a/hubgrep_indexer/models/repositories/abstract_repository.py
+++ b/hubgrep_indexer/models/repositories/abstract_repository.py
@@ -59,6 +59,14 @@ class Repository(db.Model):
         """
         delete repos from old runs, set `is_completed` to new ones
         """
+        # (can we have a table per hoster somehow? then we could just create a new table everytime..)
+        # todo: 
+        # fix crawler finishing (host_state_helpers, wait for last open block after finish)
+        # copy table
+        # rotate table (drop everything for hoster)
+        # async:
+        #   export from copy
+        #   delete copy (?)
         logger.debug(f"rotating repos for {hosting_service}")
         repo_class = cls.repo_class_for_type(hosting_service.type)
         con = db.engine.raw_connection()


### PR DESCRIPTION
heyhey

i started taking some notes on waiting for timed out blocks or slow blocks in a run.
the case would be, that the "last block" triggered an export, while we still have some unanswered blocks open.
that happens in the beginning for the small hosters, since it takes much longer to query an actual block, than to just notice that there is nothing, and return.

also, we will need some mechanic to delete failed blocks after we retried a few times. 