### PR TITLE
add is_empty on unified exported repos

### DIFF
--- a/hubgrep_indexer/models/repositories/gitea.py
+++ b/hubgrep_indexer/models/repositories/gitea.py
@@ -78,6 +78,7 @@ class GiteaRepository(Repository):
         false as is_archived,
         false as is_disabled,
         mirror as is_mirror,
+        empty as is_empty,
         website as homepage_url,
         html_url as repo_url
     from

--- a/hubgrep_indexer/models/repositories/github.py
+++ b/hubgrep_indexer/models/repositories/github.py
@@ -68,6 +68,7 @@ class GithubRepository(Repository):
         is_fork as is_fork,
         is_archived as is_archived,
         is_disabled as is_disabled,
+        is_empty as is_empty,
         false as is_mirror,
         homepage_url as homepage_url,
         url as repo_url

--- a/hubgrep_indexer/models/repositories/gitlab.py
+++ b/hubgrep_indexer/models/repositories/gitlab.py
@@ -105,6 +105,7 @@ class GitlabRepository(Repository):
         false as is_archived,
         false as is_disabled,
         false as is_mirror,
+        false as is_empty,
         web_url as homepage_url,
         http_url_to_repo as repo_url
     from


### PR DESCRIPTION
This is quite small, but I think its all that we need to expose is_empty in HubGrep.search - please check if I missed something for that.

depends on search PR: https://github.com/HubGrep/hubgrep_search/pull/75