### PR TITLE
add option to remove finished run from db after export

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -33,3 +33,6 @@ HUBGREP_OLD_RUN_AGE=3600
 
 # max retries per crawler block before we ignore it
 HUBGREP_BLOCK_MAX_RETRIES=3
+
+# keep the data of the last finished hoster crawl in db - needed for manual csv export
+HUBGREP_KEEP_LAST_RUN_IN_DB=1

--- a/hubgrep_indexer/cli_blueprint/repos.py
+++ b/hubgrep_indexer/cli_blueprint/repos.py
@@ -58,3 +58,19 @@ def prune_exports(keep, hosting_service=None):
         for export in old_exports_unified:
             print(f"deleting export {export}")
             export.delete_file()
+
+
+@cli_bp.cli.command(help="drop a hosting services 'finished' table")
+@click.argument("hosting_service")
+def drop_finished_run_table(hosting_service):
+    hosting_service_api_url = hosting_service
+    hosting_service: HostingService = HostingService.query.filter_by(
+        api_url=hosting_service_api_url
+    ).first()
+    if not hosting_service:
+        print('could not find hosting service!')
+        exit(1)
+
+    print(f"found {hosting_service}, dropping finished table")
+    hosting_service.drop_finished_run_table()
+

--- a/hubgrep_indexer/cli_blueprint/repos.py
+++ b/hubgrep_indexer/cli_blueprint/repos.py
@@ -10,8 +10,9 @@ logger = logging.getLogger(__name__)
 @cli_bp.cli.command()
 @click.argument("hosting_service")
 def export_repos(hosting_service):
+    hosting_service_api_url = hosting_service
     hosting_service: HostingService = HostingService.query.filter_by(
-        api_url=hosting_service
+        api_url=hosting_service_api_url
     ).first()
 
     hosting_service.export_repos()

--- a/hubgrep_indexer/config/dotenv.py
+++ b/hubgrep_indexer/config/dotenv.py
@@ -19,3 +19,4 @@ class DotEnvConfig(Config):
     LOGLEVEL = os.environ.get("HUBGREP_INDEXER_LOGLEVEL", "debug")
 
     BLOCK_MAX_RETRIES = int(os.environ.get("HUBGREP_BLOCK_MAX_RETRIES", 3))
+    KEEP_LAST_RUN_IN_DB = bool(int(os.environ.get("HUBGREP_KEEP_LAST_RUN_IN_DB", 1)))

--- a/hubgrep_indexer/config/testing.py
+++ b/hubgrep_indexer/config/testing.py
@@ -19,3 +19,4 @@ class TestingConfig(Config):
     LOGIN_DISABLED = True
 
     BLOCK_MAX_RETRIES = 3
+    KEEP_LAST_RUN_IN_DB = 1

--- a/hubgrep_indexer/models/hosting_service.py
+++ b/hubgrep_indexer/models/hosting_service.py
@@ -164,12 +164,14 @@ class HostingService(db.Model):
         self.export_repos()
         logger.debug(f"export for {self} finished")
         if not current_app.config['KEEP_LAST_RUN_IN_DB']:
-            logger.debug(f"dropping table for exported {self}")
+            self.drop_finished_run_table()
 
-            target_table = Repository.get_finished_table_name(self)
-            with TableHelper._cursor() as cur:
-                TableHelper.drop_table(cur, target_table)
+    def drop_finished_run_table(self):
+        logger.debug(f"dropping table for exported {self}")
 
+        target_table = Repository.get_finished_table_name(self)
+        with TableHelper._cursor() as cur:
+            TableHelper.drop_table(cur, target_table)
 
     @property
     def repos(self) -> ResultProxy:


### PR DESCRIPTION
The indexer crashed since the hdd was too small to keep the data of two runs in the database: the current run, and the latest finished run.

until now we kept the table of the finished run to be able manually export to csv - which is not really needed, so we could just throw the table away after creating the exports.

this pr adds an optional envvar: if `HUBGREP_KEEP_LAST_RUN_IN_DB` is 0, we delete the table after export, otherwise (the default) it works as before, and we "rotate" the tables when a run finished.